### PR TITLE
Fix broken pencil menu

### DIFF
--- a/ScratchWikiSkin.php
+++ b/ScratchWikiSkin.php
@@ -138,9 +138,9 @@ class ScratchWikiSkinTemplate extends BaseTemplate{
 				<h1><?php $this->html('title')?>
 				<div id=pagefctbtn></div>
 				<ul id=pagefctdropdown class="dropdownmenu box">
-<?				foreach ($this->data['content_actions'] as $key => $tab):?>
+<?php				foreach ($this->data['content_actions'] as $key => $tab):?>
 					<?=$this->makeListItem($key, $tab)?>
-<?				endforeach?>
+<?php				endforeach?>
 				</ul>
 				</h1>
 				<div class=box-content>


### PR DESCRIPTION
The pencil menu was broken thanks to the `<?php` tag being opened as `<?` instead - this fixes that.